### PR TITLE
Show log for single file with tortoisegit

### DIFF
--- a/BasicSccProvider.cs
+++ b/BasicSccProvider.cs
@@ -323,6 +323,15 @@ namespace GitScc
             RunDetatched(tortoiseGitPath, "/command:commit");
         }
 
+        private string GetTargetPath(GitToolCommand command)
+        {
+            var workingDirectory = sccService.CurrentGitWorkingDirectory;
+            if (command.Scope == CommandScope.Project) return workingDirectory;
+            var fileName = sccService.GetSelectFileName();
+            if (fileName == sccService.GetSolutionFileName()) return workingDirectory;
+            return fileName;
+        }
+
         private void OnGitTorCommandExec(object sender, EventArgs e)
         {
             var menuCommand = sender as MenuCommand;
@@ -333,8 +342,11 @@ namespace GitScc
                 Debug.WriteLine(string.Format(CultureInfo.CurrentCulture,
                                   "Run GitTor Command {0}", GitToolCommands.GitTorCommands[idx].Command));
 
+                var cmd = GitToolCommands.GitTorCommands[idx];
+                var targetPath = GetTargetPath(cmd);
+
                 var tortoiseGitPath = GitSccOptions.Current.TortoiseGitPath;
-                RunDetatched(tortoiseGitPath, GitToolCommands.GitTorCommands[idx].Command + " /path:\"" + sccService.CurrentGitWorkingDirectory + "\"");
+                RunDetatched(tortoiseGitPath, cmd.Command + " /path:\"" + targetPath + "\"");
             }
         }
 

--- a/GitToolCommands.cs
+++ b/GitToolCommands.cs
@@ -7,14 +7,21 @@ namespace GitScc
 {
     class GitToolCommand
     {
+        public CommandScope Scope { get; set; }
         public string Name { get; set; }
         public string Command { get; set; }
         
-        public GitToolCommand(string name, string Command)
+        public GitToolCommand(string name, string Command, CommandScope scope = CommandScope.Project)
         {
             this.Name = name;
             this.Command = Command;
+            Scope = scope;
         }
+    }
+
+    public enum CommandScope
+    {
+        File, Project
     }
 
     static class GitToolCommands
@@ -28,7 +35,7 @@ namespace GitScc
             new GitToolCommand("Rebase", "/command:rebase"), 
             new GitToolCommand("Resolve", "/command:resolve"), 
             new GitToolCommand("Revert", "/command:revert"), 
-            new GitToolCommand("Show Log", "/command:log"), 
+            new GitToolCommand("Show Log", "/command:log", CommandScope.File), 
             new GitToolCommand("Switch", "/command:switch"), 
             new GitToolCommand("Sync", "/command:sync"), 
             new GitToolCommand("Tag", "/command:Tag"), 


### PR DESCRIPTION
Hey, it's a bit confusing that selecting "Show log" when highlighting a file shows all changes for the entire project, especially since the "show log" dialog has an option to switch to showing all changes. I hacked something together so I could mark a command to pick a file instead.
