### PR TITLE
Declutter UI

### DIFF
--- a/BasicSccProvider.cs
+++ b/BasicSccProvider.cs
@@ -136,10 +136,6 @@ namespace GitScc
                 cmd = new CommandID(GuidList.guidSccProviderCmdSet, CommandId.icmdPendingChangesCommitToBranch);
                 menu = new MenuCommand(new EventHandler(OnSwitchBranchCommand), cmd);
                 mcs.AddCommand(menu);
-
-                cmd = new CommandID(GuidList.guidSccProviderCmdSet, CommandId.icmdSccCommandAbout);
-                menu = new MenuCommand(new EventHandler(OnAbout), cmd);
-                mcs.AddCommand(menu);
             }
 
 
@@ -250,7 +246,6 @@ namespace GitScc
                     if (sccService.IsSolutionGitControlled) cmdf |= OLECMDF.OLECMDF_ENABLED;
                     break;
 
-                case CommandId.icmdSccCommandAbout:
                 case CommandId.icmdSccCommandRefresh:
                     //if (sccService.IsSolutionGitControlled)
                         cmdf |= OLECMDF.OLECMDF_ENABLED;
@@ -399,13 +394,6 @@ namespace GitScc
                 var gitExtensionPath = GitSccOptions.Current.GitExtensionPath;
                 RunDetatched(gitExtensionPath, GitToolCommands.GitExtCommands[idx].Command);
             }
-        }
-        
-        private void OnAbout(object sender, EventArgs e)
-        {
-            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            path = Path.Combine(path, "Readme.htm");
-            Process.Start(path);
         }
         
         private void ShowPendingChangesWindow(object sender, EventArgs e)

--- a/CommandId.cs
+++ b/CommandId.cs
@@ -27,7 +27,6 @@ namespace GitScc
 
         public const int icmdPendingChangesRefresh = 0x114;
         public const int icmdHistoryViewRefresh = 0x115;
-        public const int icmdSccCommandAbout = 0x116;
 
 
         // Define the list of menus (these include toolbars)

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -193,7 +193,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>IconAndText</CommandFlag>
         <Strings>
-          <ButtonText>Pending Changes</ButtonText>
+          <ButtonText>Git Pending Changes</ButtonText>
         </Strings>
       </Button>
 
@@ -279,14 +279,9 @@
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
     </CommandPlacement>
 
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
+    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0250">
+      <!-- View -> Other Windows where other similar commands are located -->
+      <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
     </CommandPlacement>
 
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -131,7 +131,7 @@
         </Strings>
       </Button>
 
-      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandEditIgnore" priority="0x0103" type="Button">
+      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandEditIgnore" priority="0x0104" type="Button">
         <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconOpenIgnoreFile" />
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -142,7 +142,7 @@
         </Strings>
       </Button>
 
-      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandRefresh" priority="0x0104" type="Button">
+      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandRefresh" priority="0x0105" type="Button">
         <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconRefresh" />
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -197,7 +197,8 @@
         </Strings>
       </Button>
 
-      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0105" type="Button">
+      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0103" type="Button">
+        <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconGitBash" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -284,15 +285,6 @@
       <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
     </CommandPlacement>
 
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
-    </CommandPlacement>  
 
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandEditIgnore" priority="0x0007">
       <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup"/>

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -207,16 +207,6 @@
         </Strings>
       </Button>
 
-      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0106" type="Button">
-        <Icon guid="guidSccProviderImages" id="iconGitBash" />
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>IconAndText</CommandFlag>
-        <Strings>
-          <ButtonText>About</ButtonText>
-        </Strings>
-      </Button>
-      
       <!-- buttons on pending changes tool window's tool bar -->
       <Button guid="guidSccProviderCmdSet" id="icmdPendingChangesCommit" priority="0x0000" type="Button">
         <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup"/>
@@ -299,16 +289,6 @@
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
     </CommandPlacement>
 
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
-    </CommandPlacement>
-    
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
     </CommandPlacement>
@@ -335,10 +315,7 @@
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandGitTortoise" priority="0x0011">
       <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0020">
-      <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup"/>
-    </CommandPlacement>
-    
+
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdGitExtCommand1" priority="0x0000">
       <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowGitExt"/>
     </CommandPlacement>
@@ -377,7 +354,6 @@
 
       <IDSymbol name="icmdPendingChangesRefresh" value="0x114"/>
       <IDSymbol name="icmdHistoryViewRefresh" value="0x115"/>  
-      <IDSymbol name="icmdSccCommandAbout" value="0x116"/>
       
       <IDSymbol name="igrpGitExtCommands" value="0x800"/>
       <IDSymbol name="imnuGitExtMenu" value="0x801"/>


### PR DESCRIPTION
Moves the following items which were misplaced in the UI:
- The About command is covered by the links in Extension Manager; duplication simply clutters the UI
- The Pending Changes command belongs on the View -> Other Windows menu with other similar commands

Moves the following item to clean up the UI:
- Move the View History button to the Git sub-menu of the Solution Explorer context menus
