### PR TITLE
Fix GitFileStatusTracker returning New instead of Ignored

### DIFF
--- a/GitApi/GitFileStatusTracker.cs
+++ b/GitApi/GitFileStatusTracker.cs
@@ -318,7 +318,8 @@ namespace GitScc
                 
                 if (File.Exists(fileName))
                 {
-                    if (ignoreRules != null && ignoreRules.Any(rule => rule.IsMatch(fileName, false)))
+                    string target = fileNameRel.Replace('\\', '/');
+                    if (ignoreRules != null && ignoreRules.Any(rule => rule.IsMatch(target, false)))
                     {
                         return GitFileStatus.Ignored;
                     }


### PR DESCRIPTION
When `.hgignore` contains an entry like the following:

```
/Path/File.ext
```

Then `GitFileStatusTracker.GetFileStatusNoCacheOld` returns `GitFileStatus.New` for the file instead of `GitFileStatus.Ignored`. The problem was caused by using the absolute Windows file name instead of a relative path normalized to contain `/` as the directory separator character.
