### PR TITLE
UI handling of modification after staging

### DIFF
--- a/GitApi/GitFileStatusTracker.cs
+++ b/GitApi/GitFileStatusTracker.cs
@@ -286,6 +286,9 @@ namespace GitScc
             {
                 if (treeEntry == null)
                 {
+                    if (indexEntry.IsModified(repository.WorkTree, true))
+                        return GitFileStatus.Modified;
+
                     return GitFileStatus.Added;
                 }
                 if (!File.Exists(fileName))


### PR DESCRIPTION
If an _added_ file is modified after it is staged, report the status as modified, not staged.
