### PR TITLE
Fixed build and made Compare command more accessible

### DIFF
--- a/BasicSccProvider.cs
+++ b/BasicSccProvider.cs
@@ -358,8 +358,16 @@ namespace GitScc
 
         internal void RunDiffCommand(string file1, string file2)
         {
-            var difftoolPath = GitSccOptions.Current.DifftoolPath;
-            RunCommand(difftoolPath, "\"" + file1 + "\" \"" + file2 + "\"");
+            var diffService = (IVsDifferenceService)GetService(typeof(SVsDifferenceService));
+            if (GitSccOptions.Current.UseVsDiff && diffService != null)
+            {
+                diffService.OpenComparisonWindow(file1, file2);
+            }
+            else
+            {
+                var difftoolPath = GitSccOptions.Current.DifftoolPath;
+                RunCommand(difftoolPath, "\"" + file1 + "\" \"" + file2 + "\"");
+            }            
         }
 
         private void OnInitCommand(object sender, EventArgs e)

--- a/BasicSccProvider.csproj
+++ b/BasicSccProvider.csproj
@@ -58,6 +58,10 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 11.0\VSSDK\VisualStudioIntegration\Common\Assemblies\v4.0\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/GitSccOptions.cs
+++ b/GitSccOptions.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.IO;
 using System.Xml.Serialization;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace GitScc
 {
@@ -24,6 +26,7 @@ namespace GitScc
         public bool DisableAutoRefresh { get; set; }
         public bool DisableAutoLoad { get; set; }
         public bool NotUseUTF8FileNames { get; set; }
+        public bool UseVsDiff { get; set; }
 
         private static GitSccOptions gitSccOptions;
 
@@ -96,6 +99,10 @@ namespace GitScc
             }
 
             if (string.IsNullOrEmpty(DifftoolPath)) DifftoolPath = "diffmerge.exe";
+
+            bool diffServiceAvailable = Package.GetGlobalService(typeof(SVsDifferenceService)) != null;
+            if (!diffServiceAvailable)
+                UseVsDiff = false;
         }
 
         internal void SaveConfig()

--- a/GitUI/UI/MainToolBar.xaml
+++ b/GitUI/UI/MainToolBar.xaml
@@ -64,7 +64,7 @@
         <Label Content="Commits" Height="28" HorizontalAlignment="Left" Margin="10,61,0,0" VerticalAlignment="Top" FontSize="10" />
         <TextBox VerticalAlignment="Bottom" Margin="60,0,250,5.04" x:Name="txtSearch" TextChanged="txtSearch_TextChanged" PreviewKeyDown="txtSearch_PreviewKeyDown" PreviewMouseDown="txtSearch_PreviewMouseDown" />
         <ListBox Height="100" Margin="60,0,250,-95.96" VerticalAlignment="Bottom" x:Name="lstSearch" PreviewKeyDown="lstSearch_PreviewKeyDown" MouseDoubleClick="lstSearch_MouseDoubleClick" />
-        <Button Content="Compare" HorizontalAlignment="Right" Margin="0,46,107,0" Template="{DynamicResource CompareButtonControlTemplate}" ToolTip="Compare ..." x:Name="btnCompare" Click="btnCompare_Click" RenderTransformOrigin="1.917,0.512"/>
+        <Button Content="Compare" HorizontalAlignment="Right" Margin="0,46,107,0" Template="{DynamicResource CompareButtonControlTemplate}" ToolTip="Compare..." x:Name="btnCompare" Click="btnCompare_Click" RenderTransformOrigin="1.917,0.512"/>
         <TextBlock HorizontalAlignment="Right" Margin="0,0,144,14" TextWrapping="NoWrap" Text="123456" Width="88.38" Foreground="#FFFF5656" x:Name="txtCommit1" FontSize="10" Height="24" VerticalAlignment="Bottom" />
         <TextBlock HorizontalAlignment="Right" Height="24" Margin="0,0,144,0" TextWrapping="NoWrap" Text="123456" VerticalAlignment="Bottom" Width="88.38" Foreground="#FFFF5656" x:Name="txtCommit2" FontSize="10" />
         <Label Content="Selected Commits &#xd;&#xa;to compare" Height="46" HorizontalAlignment="Right" Margin="0,11,137,0" VerticalAlignment="Top" FontSize="10" Width="99.897" x:Name="lblSelectedCommits"/>

--- a/GitUI/UI/PendingChanges.xaml
+++ b/GitUI/UI/PendingChanges.xaml
@@ -132,7 +132,7 @@
 						<ContextMenu>
 							<MenuItem Header="Stage File" Name="menuStage" Click="menuStage_Click" />
 							<MenuItem Header="Un-Stage File" Name="menuUnstage" Click="menuUnstage_Click" />
-							<MenuItem Header="Compare ..." Name="menuCompare" Click="menuCompare_Click" Visibility="Collapsed" />
+							<MenuItem Header="Compare..." Name="menuCompare" Click="menuCompare_Click" Visibility="Collapsed" />
 							<MenuItem Header="Undo File Changes" Name="menuUndo" Click="menuUndo_Click"/>
 							<MenuItem Header="Delete File" Name="menuDeleteFile" Click="menuDeleteFile_Click"/>
 							<MenuItem Header="Ignore File" Name="menuIgnore" Click="menuIgnore_Click" >

--- a/PendingChangesView.xaml
+++ b/PendingChangesView.xaml
@@ -87,7 +87,7 @@
 					<ContextMenu>
 						<MenuItem Header="Stage File" Name="menuStage" Click="menuStage_Click" />
 						<MenuItem Header="Un-Stage File" Name="menuUnstage" Click="menuUnstage_Click" />
-						<MenuItem Header="Compare ..." Name="menuCompare" Click="menuCompare_Click" />
+						<MenuItem Header="Compare..." Name="menuCompare" Click="menuCompare_Click" />
 						<MenuItem Header="Undo File Changes" Name="menuUndo" Click="menuUndo_Click"/>
 						<MenuItem Header="Delete File" Name="menuDeleteFile" Click="menuDeleteFile_Click"/>
 						<MenuItem Header="Ignore file" Name="menuIgnore" Click="menuIgnore_Click" >

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -71,6 +71,11 @@
       <Group guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowGitTor" priority="0x0000">
         <Parent guid="guidSccProviderCmdSet" id="imnuPendingChangesToolWindowGitTor"/>
       </Group>
+
+      <!-- Document TabWnd context menu -->
+      <Group guid="guidSccProviderCmdSet" id="igrpDocTabWnd" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_EZDOCWINTAB"/>
+      </Group>
       
     </Groups>
     
@@ -110,7 +115,6 @@
       </Button>
 
       <Button guid="guidSccProviderCmdSet" id="icmdSccCommandCompare" priority="0x0101" type="Button">
-        <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconCompare" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -301,6 +305,16 @@
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
     </CommandPlacement>
 
+    <!-- Item context menu | Compare  -->
+    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandCompare" priority="0x0003">
+      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
+    </CommandPlacement>
+
+    <!-- Document Tab context menu | Compare  -->
+    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandCompare" priority="0x0600">
+      <Parent guid="guidSccProviderCmdSet" id="igrpDocTabWnd"/>
+    </CommandPlacement>
+
     <!--<CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0004">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
     </CommandPlacement>
@@ -380,6 +394,7 @@
       
       <IDSymbol name="imnuGitSourceControlMenu" value="0x205"/>
       <IDSymbol name="igrpSourceControlCommands" value="0x301"/>
+      <IDSymbol name="igrpDocTabWnd" value="0x302"/>
 
       <IDSymbol name="imnuHistoryToolWindowToolbarMenu" value="0x200"/>
       <IDSymbol name="igrpHistoryToolWindowToolbarGroup" value="0x201"/>

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -116,7 +116,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>IconAndText</CommandFlag>
         <Strings>
-          <ButtonText>Compare ...</ButtonText>
+          <ButtonText>Compare...</ButtonText>
         </Strings>
       </Button>
       

--- a/SccProviderOptionsControl.cs
+++ b/SccProviderOptionsControl.cs
@@ -52,6 +52,7 @@ namespace GitScc
         private CheckBox checkBox4;
         private CheckBox checkBox5;
         private CheckBox checkBox6;
+        private CheckBox useVsDiffChk;
         // The parent page, use to persist data
         private SccProviderOptions _customPage;
 
@@ -106,6 +107,7 @@ namespace GitScc
             this.checkBox4 = new System.Windows.Forms.CheckBox();
             this.checkBox5 = new System.Windows.Forms.CheckBox();
             this.checkBox6 = new System.Windows.Forms.CheckBox();
+            this.useVsDiffChk = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // openFileDialog1
@@ -115,15 +117,15 @@ namespace GitScc
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 10);
+            this.label1.Location = new System.Drawing.Point(3, 5);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(159, 13);
+            this.label1.Size = new System.Drawing.Size(162, 13);
             this.label1.TabIndex = 11;
-            this.label1.Text = "Path to Git for Windows (git.exe)";
+            this.label1.Text = "Path to Git for Windows (git.exe):";
             // 
             // textBox1
             // 
-            this.textBox1.Location = new System.Drawing.Point(6, 26);
+            this.textBox1.Location = new System.Drawing.Point(6, 21);
             this.textBox1.Name = "textBox1";
             this.textBox1.Size = new System.Drawing.Size(283, 20);
             this.textBox1.TabIndex = 12;
@@ -131,15 +133,15 @@ namespace GitScc
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 63);
+            this.label2.Location = new System.Drawing.Point(3, 51);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(111, 13);
+            this.label2.Size = new System.Drawing.Size(114, 13);
             this.label2.TabIndex = 13;
-            this.label2.Text = "Path to Git Extensions";
+            this.label2.Text = "Path to Git Extensions:";
             // 
             // textBox2
             // 
-            this.textBox2.Location = new System.Drawing.Point(6, 80);
+            this.textBox2.Location = new System.Drawing.Point(6, 68);
             this.textBox2.Name = "textBox2";
             this.textBox2.Size = new System.Drawing.Size(283, 20);
             this.textBox2.TabIndex = 14;
@@ -149,9 +151,9 @@ namespace GitScc
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(3, 209);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(286, 13);
+            this.label3.Size = new System.Drawing.Size(321, 13);
             this.label3.TabIndex = 15;
-            this.label3.Text = "Path to Diff Tool (Optional, by default diffmerge.exe is used)";
+            this.label3.Text = "Path to external diff tool (optional, by default diffmerge.exe is used):";
             // 
             // textBox3
             // 
@@ -162,7 +164,7 @@ namespace GitScc
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(295, 23);
+            this.button1.Location = new System.Drawing.Point(295, 19);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(75, 23);
             this.button1.TabIndex = 17;
@@ -172,7 +174,7 @@ namespace GitScc
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(295, 77);
+            this.button2.Location = new System.Drawing.Point(295, 66);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(75, 23);
             this.button2.TabIndex = 18;
@@ -182,7 +184,7 @@ namespace GitScc
             // 
             // button3
             // 
-            this.button3.Location = new System.Drawing.Point(295, 223);
+            this.button3.Location = new System.Drawing.Point(295, 224);
             this.button3.Name = "button3";
             this.button3.Size = new System.Drawing.Size(75, 23);
             this.button3.TabIndex = 19;
@@ -193,22 +195,22 @@ namespace GitScc
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 129);
+            this.label4.Location = new System.Drawing.Point(3, 117);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(95, 13);
+            this.label4.Size = new System.Drawing.Size(98, 13);
             this.label4.TabIndex = 20;
-            this.label4.Text = "Path to TortoiseGit";
+            this.label4.Text = "Path to TortoiseGit:";
             // 
             // textBox4
             // 
-            this.textBox4.Location = new System.Drawing.Point(6, 146);
+            this.textBox4.Location = new System.Drawing.Point(6, 134);
             this.textBox4.Name = "textBox4";
             this.textBox4.Size = new System.Drawing.Size(283, 20);
             this.textBox4.TabIndex = 21;
             // 
             // button4
             // 
-            this.button4.Location = new System.Drawing.Point(295, 143);
+            this.button4.Location = new System.Drawing.Point(295, 132);
             this.button4.Name = "button4";
             this.button4.Size = new System.Drawing.Size(75, 23);
             this.button4.TabIndex = 22;
@@ -219,7 +221,7 @@ namespace GitScc
             // checkBox1
             // 
             this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(66, 105);
+            this.checkBox1.Location = new System.Drawing.Point(66, 93);
             this.checkBox1.Name = "checkBox1";
             this.checkBox1.Size = new System.Drawing.Size(220, 17);
             this.checkBox1.TabIndex = 23;
@@ -229,7 +231,7 @@ namespace GitScc
             // checkBox2
             // 
             this.checkBox2.AutoSize = true;
-            this.checkBox2.Location = new System.Drawing.Point(66, 172);
+            this.checkBox2.Location = new System.Drawing.Point(66, 160);
             this.checkBox2.Name = "checkBox2";
             this.checkBox2.Size = new System.Drawing.Size(204, 17);
             this.checkBox2.TabIndex = 24;
@@ -240,29 +242,29 @@ namespace GitScc
             // 
             this.checkBox3.AutoSize = true;
             this.checkBox3.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.checkBox3.Location = new System.Drawing.Point(6, 264);
+            this.checkBox3.Location = new System.Drawing.Point(6, 262);
             this.checkBox3.Name = "checkBox3";
-            this.checkBox3.Size = new System.Drawing.Size(168, 17);
+            this.checkBox3.Size = new System.Drawing.Size(163, 17);
             this.checkBox3.TabIndex = 25;
-            this.checkBox3.Text = "Use TortoiseGit Style Icon Set";
+            this.checkBox3.Text = "Use TortoiseGit style icon set";
             this.checkBox3.UseVisualStyleBackColor = true;
             // 
             // checkBox4
             // 
             this.checkBox4.AutoSize = true;
             this.checkBox4.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.checkBox4.Location = new System.Drawing.Point(244, 264);
+            this.checkBox4.Location = new System.Drawing.Point(244, 262);
             this.checkBox4.Name = "checkBox4";
-            this.checkBox4.Size = new System.Drawing.Size(126, 17);
+            this.checkBox4.Size = new System.Drawing.Size(120, 17);
             this.checkBox4.TabIndex = 26;
-            this.checkBox4.Text = "Disable Auto-Refresh";
+            this.checkBox4.Text = "Disable auto-refresh";
             this.checkBox4.UseVisualStyleBackColor = true;
             // 
             // checkBox5
             // 
             this.checkBox5.AutoSize = true;
             this.checkBox5.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.checkBox5.Location = new System.Drawing.Point(6, 289);
+            this.checkBox5.Location = new System.Drawing.Point(6, 287);
             this.checkBox5.Name = "checkBox5";
             this.checkBox5.Size = new System.Drawing.Size(303, 17);
             this.checkBox5.TabIndex = 27;
@@ -273,18 +275,31 @@ namespace GitScc
             // 
             this.checkBox6.AutoSize = true;
             this.checkBox6.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.checkBox6.Location = new System.Drawing.Point(6, 313);
+            this.checkBox6.Location = new System.Drawing.Point(6, 311);
             this.checkBox6.Name = "checkBox6";
             this.checkBox6.Size = new System.Drawing.Size(205, 17);
             this.checkBox6.TabIndex = 28;
             this.checkBox6.Text = "Disable UTF-8 file names (Git 1.7.10+)";
             this.checkBox6.UseVisualStyleBackColor = true;
             // 
+            // useVsDiffChk
+            // 
+            this.useVsDiffChk.AutoSize = true;
+            this.useVsDiffChk.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.useVsDiffChk.Location = new System.Drawing.Point(6, 189);
+            this.useVsDiffChk.Name = "useVsDiffChk";
+            this.useVsDiffChk.Size = new System.Drawing.Size(173, 17);
+            this.useVsDiffChk.TabIndex = 29;
+            this.useVsDiffChk.Text = "Use Visual Studio Diff Window:";
+            this.useVsDiffChk.UseVisualStyleBackColor = true;
+            this.useVsDiffChk.CheckedChanged += new System.EventHandler(this.useVsDiffChk_CheckedChanged);
+            // 
             // SccProviderOptionsControl
             // 
             this.AllowDrop = true;
             this.AutoScroll = true;
             this.AutoSize = true;
+            this.Controls.Add(this.useVsDiffChk);
             this.Controls.Add(this.checkBox6);
             this.Controls.Add(this.checkBox5);
             this.Controls.Add(this.checkBox4);
@@ -304,7 +319,7 @@ namespace GitScc
             this.Controls.Add(this.textBox1);
             this.Controls.Add(this.label1);
             this.Name = "SccProviderOptionsControl";
-            this.Size = new System.Drawing.Size(1559, 604);
+            this.Size = new System.Drawing.Size(435, 340);
             this.Load += new System.EventHandler(this.SccProviderOptionsControl_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -332,6 +347,7 @@ namespace GitScc
             this.checkBox4.Checked = GitSccOptions.Current.DisableAutoRefresh;
             this.checkBox5.Checked = GitSccOptions.Current.DisableAutoLoad;
             this.checkBox6.Checked = GitSccOptions.Current.NotUseUTF8FileNames;
+            this.useVsDiffChk.Checked = GitSccOptions.Current.UseVsDiff;
         }
 
         private void button1_Click(object sender, EventArgs e)
@@ -376,12 +392,19 @@ namespace GitScc
             GitSccOptions.Current.DisableAutoRefresh = this.checkBox4.Checked;
             GitSccOptions.Current.DisableAutoLoad = this.checkBox5.Checked;
             GitSccOptions.Current.NotUseUTF8FileNames = this.checkBox6.Checked;
+            GitSccOptions.Current.UseVsDiff = this.useVsDiffChk.Checked;
 
             GitBash.UseUTF8FileNames = !GitSccOptions.Current.NotUseUTF8FileNames;
             GitSccOptions.Current.SaveConfig();
 
             SccProviderService sccProviderService = (SccProviderService)GetService(typeof(SccProviderService));
             sccProviderService.Refresh();
+        }
+
+        private void useVsDiffChk_CheckedChanged(object sender, EventArgs e)
+        {
+            label3.Enabled = textBox3.Enabled = button3.Enabled 
+                = !useVsDiffChk.Checked;
         }
 
     }

--- a/SccProviderOptionsControl.resx
+++ b/SccProviderOptionsControl.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>17, 12</value>
   </metadata>
 </root>


### PR DESCRIPTION
As the Compare is so commonly used, pulled it out of the sub-menu in the solution explorer. Also made it accessible from the document tab context menu.
