### PR TITLE
Refresh pending changes

### DIFF
--- a/BasicSccProvider.cs
+++ b/BasicSccProvider.cs
@@ -324,8 +324,7 @@ namespace GitScc
 
         private void OnRefreshCommand(object sender, EventArgs e)
         {
-            sccService.NoRefresh = false;
-            sccService.Refresh();
+            GetToolWindowPane<PendingChangesToolWindow>().Refresh(sccService.CurrentTracker, true);
         }
 
         private void OnCompareCommand(object sender, EventArgs e)

--- a/GitApi/GitApi.csproj
+++ b/GitApi/GitApi.csproj
@@ -29,6 +29,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.84.0.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73">
+      <SpecificVersion>False</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
With auto-refresh disabled, manually clicking on the refresh button was not working.  I changed the button click to call the Refresh method on the ToolWindowPane directly.

PS. I had to add the references in the first commit, because a clean pull and solution build complained about these missing Resource files.  
