### PR TITLE
Updates

### DIFF
--- a/BasicSccProvider.Tests/RepositoryGraphTest.cs
+++ b/BasicSccProvider.Tests/RepositoryGraphTest.cs
@@ -1,7 +1,7 @@
 ﻿using GitScc.DataServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
+using Constants = NGit.Constants;
 
 namespace BasicSccProvider.Tests
 {
@@ -82,7 +82,7 @@ namespace BasicSccProvider.Tests
         public void TreeDiffTest()
         {
             RepositoryGraph repo = new RepositoryGraph(repodir);
-            var changes = repo.GetChanges("master", "HEAD");
+            var changes = repo.GetChanges(Constants.MASTER, Constants.HEAD);
             foreach (var change in changes)
             {
                 Console.WriteLine("{0}:{1}", change.ChangeType, change.Name);

--- a/GitApi/GitFileStatusTracker.cs
+++ b/GitApi/GitFileStatusTracker.cs
@@ -9,6 +9,7 @@ using NGit;
 using NGit.Api;
 using NGit.Diff;
 using NGit.Dircache;
+using NGit.Errors;
 using NGit.Ignore;
 using NGit.Revwalk;
 using NGit.Storage.File;
@@ -92,7 +93,12 @@ namespace GitScc
                             var treeId = ObjectId.FromString(repository.Open(head).GetBytes(), 5);
                             this.commitTree = new Tree(repository, treeId, repository.Open(treeId).GetBytes());
                         }
-                        this.index = repository.GetIndex();
+
+                        if (repository.IsBare)
+                            throw new NoWorkTreeException();
+
+                        this.index = new GitIndex(repository);
+                        this.index.Read();
                         this.index.RereadIfNecessary();
 
                         try

--- a/GitUI/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/GitUI/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -11,14 +11,12 @@ namespace Standard
     using System.Runtime.ConstrainedExecution;
     using System.Runtime.InteropServices;
     using System.Runtime.InteropServices.ComTypes;
-    using System.Security.Permissions;
+    using System.Security;
     using System.Text;
     using Microsoft.Win32.SafeHandles;
 
     // Some COM interfaces and Win32 structures are already declared in the framework.
     // Interesting ones to remember in System.Runtime.InteropServices.ComTypes are:
-    using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
-    using IPersistFile = System.Runtime.InteropServices.ComTypes.IPersistFile;
     using IStream = System.Runtime.InteropServices.ComTypes.IStream;
 
     #region Native Values
@@ -1337,7 +1335,7 @@ namespace Standard
 
     internal sealed class SafeFindHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        [SecurityPermission(SecurityAction.LinkDemand, UnmanagedCode = true)]
+        [SecurityCritical]
         private SafeFindHandle() : base(true) { }
 
         protected override bool ReleaseHandle()


### PR DESCRIPTION
- Use `SecurityCritical` attribute instead of `SecurityPermission`
- Use provided constants instead of hard-coded literals
- Update NGit submodule to fix loading of configuration files

This pull request is a prerequisite for the Git Diff Margin pull request.
