### PR TITLE
Update author to indicate project includes other contributors

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
   <Identifier Id="C4128D99-2000-41D1-A6C3-704E6C1A3DE2">
     <Name>Git Source Control Provider</Name>
-    <Author>Yiyisun@hotmail.com</Author>
+    <Author>Yiyi Sun et. al.</Author>
     <Version>1.0.2</Version>
     <Description xml:space="preserve">Git Source Control Provider is a plug-in that integrates git with Visual Studio.</Description>
     <Locale>1033</Locale>


### PR DESCRIPTION
@laurentkempe has also requested that his name be added to a list of project contributors on the Git Source Control Provider home page. Since the project now has several contributors, it's probably a good idea to start a running list. So far I see the following (alphabetical order after Yiyi as the primary author).
- Yiyi Sun
- Javier Castro
- Tim Chen
- Sean Collins
- Sam Harwell
- Laurent Kempé
- Daniel Pihlstrom
- Duncan Smart
- Eli Young
