### PR TITLE
Commands

### DIFF
--- a/BasicSccProvider.cs
+++ b/BasicSccProvider.cs
@@ -145,11 +145,6 @@ namespace GitScc
                 cmd = new CommandID(GuidList.guidSccProviderCmdSet, CommandId.icmdPendingChangesAmend);
                 menu = new MenuCommand(new EventHandler(OnAmendCommitCommand), cmd);
                 mcs.AddCommand(menu);
-
-            
-                cmd = new CommandID(GuidList.guidSccProviderCmdSet, CommandId.icmdSccCommandAbout);
-                menu = new MenuCommand(new EventHandler(OnAbout), cmd);
-                mcs.AddCommand(menu);
             }
 
 
@@ -262,7 +257,6 @@ namespace GitScc
                     if (GitBash.Exists && sccService.IsSolutionGitControlled) cmdf |= OLECMDF.OLECMDF_ENABLED;
                     break;
 
-                case CommandId.icmdSccCommandAbout:
                 case CommandId.icmdSccCommandRefresh:
                     //if (sccService.IsSolutionGitControlled)
                         cmdf |= OLECMDF.OLECMDF_ENABLED;
@@ -423,13 +417,6 @@ namespace GitScc
                 var gitExtensionPath = GitSccOptions.Current.GitExtensionPath;
                 RunDetatched(gitExtensionPath, GitToolCommands.GitExtCommands[idx].Command);
             }
-        }
-        
-        private void OnAbout(object sender, EventArgs e)
-        {
-            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            path = Path.Combine(path, "Readme.html");
-            Process.Start(path);
         }
         
         private void ShowPendingChangesWindow(object sender, EventArgs e)

--- a/BasicSccProvider.csproj
+++ b/BasicSccProvider.csproj
@@ -119,6 +119,7 @@
     <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="GitToolCommands.cs" />
     <Compile Include="GitSccOptions.cs" />
+    <Compile Include="GlobalCommandHook.cs" />
     <Compile Include="PendingChangesView.xaml.cs">
       <DependentUpon>PendingChangesView.xaml</DependentUpon>
     </Compile>

--- a/CommandId.cs
+++ b/CommandId.cs
@@ -27,8 +27,6 @@ namespace GitScc
 
         public const int icmdPendingChangesRefresh = 0x114;
         public const int icmdHistoryViewRefresh = 0x115;
-        public const int icmdSccCommandAbout = 0x116;
-
 
         // Define the list of menus (these include toolbars)
         public const int imnuHistoryToolWindowToolbarMenu = 0x200;

--- a/GlobalCommandHook.cs
+++ b/GlobalCommandHook.cs
@@ -1,0 +1,159 @@
+﻿namespace GitScc
+{
+    using System;
+    using System.Collections.Generic;
+    using CommandID = System.ComponentModel.Design.CommandID;
+    using ErrorHandler = Microsoft.VisualStudio.ErrorHandler;
+    using IOleCommandTarget = Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget;
+    using IVsRegisterPriorityCommandTarget = Microsoft.VisualStudio.Shell.Interop.IVsRegisterPriorityCommandTarget;
+    using OLECMD = Microsoft.VisualStudio.OLE.Interop.OLECMD;
+    using OleConstants = Microsoft.VisualStudio.OLE.Interop.Constants;
+    using SVsRegisterPriorityCommandTarget = Microsoft.VisualStudio.Shell.Interop.SVsRegisterPriorityCommandTarget;
+
+    internal sealed class GlobalCommandHook : IOleCommandTarget
+    {
+        private static GlobalCommandHook _instance;
+
+        private readonly BasicSccProvider _provider;
+        private readonly Dictionary<Guid, Dictionary<int, EventHandler>> _commandMap = new Dictionary<Guid, Dictionary<int, EventHandler>>();
+        private bool _hooked;
+        private uint _cookie;
+
+        private GlobalCommandHook(BasicSccProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public static GlobalCommandHook GetInstance(BasicSccProvider provider)
+        {
+            if (provider == null)
+                throw new ArgumentNullException("provider");
+
+            if (_instance == null)
+                _instance = new GlobalCommandHook(provider);
+
+            return _instance;
+        }
+
+        public void HookCommand(CommandID command, EventHandler handler)
+        {
+            if (command == null)
+                throw new ArgumentNullException("command");
+            else if (handler == null)
+                throw new ArgumentNullException("handler");
+
+            Dictionary<int, EventHandler> map;
+            if (!_commandMap.TryGetValue(command.Guid, out map))
+            {
+                map = new Dictionary<int, EventHandler>();
+                _commandMap[command.Guid] = map;
+            }
+
+            EventHandler handlers;
+            if (!map.TryGetValue(command.ID, out handlers))
+                handlers = null;
+
+            map[command.ID] = (handlers + handler);
+
+            if (!_hooked)
+            {
+                IVsRegisterPriorityCommandTarget svc = (IVsRegisterPriorityCommandTarget)_provider.GetService(typeof(SVsRegisterPriorityCommandTarget));
+                if (svc != null && ErrorHandler.Succeeded(svc.RegisterPriorityCommandTarget(0, this, out _cookie)))
+                    _hooked = true;
+            }
+        }
+
+        public void UnhookCommand(CommandID command, EventHandler handler)
+        {
+            if (command == null)
+                throw new ArgumentNullException("command");
+            else if (handler == null)
+                throw new ArgumentNullException("handler");
+
+            Dictionary<int, EventHandler> map;
+            if (!_commandMap.TryGetValue(command.Guid, out map))
+                return;
+
+            EventHandler handlers;
+            if (!map.TryGetValue(command.ID, out handlers))
+                return;
+
+            handlers -= handler;
+
+            if (handlers == null)
+            {
+                map.Remove(command.ID);
+
+                if (map.Count == 0)
+                {
+                    _commandMap.Remove(command.Guid);
+
+                    if (_commandMap.Count == 0)
+                    {
+                        Unhook();
+                    }
+                }
+
+                return;
+            }
+
+            map[command.ID] = (handlers + handler);
+        }
+
+        private void Unhook()
+        {
+            if (_hooked)
+            {
+                _hooked = false;
+                ((IVsRegisterPriorityCommandTarget)_provider.GetService(typeof(SVsRegisterPriorityCommandTarget))).UnregisterPriorityCommandTarget(_cookie);
+            }
+        }
+
+        private static bool GuidRefIsNull(ref Guid pguidCmdGroup)
+        {
+            // According to MSDN the Guid for the command group can be null and in this case the default
+            // command group should be used. Given the interop definition of IOleCommandTarget, the only way
+            // to detect a null guid is to try to access it and catch the NullReferenceExeption.
+            Guid commandGroup;
+            try
+            {
+                commandGroup = pguidCmdGroup;
+            }
+            catch (NullReferenceException)
+            {
+                // Here we assume that the only reason for the exception is a null guidGroup.
+                // We do not handle the default command group as definied in the spec for IOleCommandTarget,
+                // so we have to return OLECMDERR_E_NOTSUPPORTED.
+                return true;
+            }
+
+            return false;
+        }
+
+        int IOleCommandTarget.Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
+        {
+            // Exit as quickly as possible without creating exceptions. This function is performance critical!
+
+            if (GuidRefIsNull(ref pguidCmdGroup))
+                return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
+
+            Dictionary<int, EventHandler> cmdMap;
+            if (!_commandMap.TryGetValue(pguidCmdGroup, out cmdMap))
+                return (int)OleConstants.OLECMDERR_E_UNKNOWNGROUP;
+
+            EventHandler handler;
+            if (cmdMap.TryGetValue(unchecked((int)nCmdID), out handler))
+            {
+                handler(this, EventArgs.Empty);
+            }
+
+            return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
+        }
+
+        int IOleCommandTarget.QueryStatus(ref Guid pguidCmdGroup, uint cCmds, OLECMD[] prgCmds, IntPtr pCmdText)
+        {
+            // Don't do anything here. This function is 100% performance critical!
+            return (int)OleConstants.OLECMDERR_E_NOTSUPPORTED;
+        }
+    }
+}

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -212,17 +212,6 @@
           <ButtonText>Git History</ButtonText>
         </Strings>
       </Button>
-
-      <Button guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0106" type="Button">
-        <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
-        <Icon guid="guidSccProviderImages" id="iconGitBash" />
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>IconAndText</CommandFlag>
-        <Strings>
-          <ButtonText>About</ButtonText>
-        </Strings>
-      </Button>
       
       <!-- buttons on pending changes tool window's tool bar -->
       <Button guid="guidSccProviderCmdSet" id="icmdPendingChangesCommit" priority="0x0000" type="Button">
@@ -332,16 +321,6 @@
       <Parent guid="guidSccProviderCmdSet" id="igrpDocTabWnd"/>
     </CommandPlacement>
     
-    <!--<CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
-    </CommandPlacement>-->
-    
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
     </CommandPlacement>
@@ -380,9 +359,6 @@
       <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup"/>
     </CommandPlacement>
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandGitTortoise" priority="0x0011">
-      <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandAbout" priority="0x0020">
       <Parent guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup"/>
     </CommandPlacement>
     
@@ -425,7 +401,6 @@
 
       <IDSymbol name="icmdPendingChangesRefresh" value="0x114"/>
       <IDSymbol name="icmdHistoryViewRefresh" value="0x115"/>  
-      <IDSymbol name="icmdSccCommandAbout" value="0x116"/>
       
       <IDSymbol name="igrpGitExtCommands" value="0x800"/>
       <IDSymbol name="imnuGitExtMenu" value="0x801"/>

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -302,17 +302,6 @@
       <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS0"/>
     </CommandPlacement>
     
-    <!-- Item context menu | Compare  -->
-    <!--<CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandCompare" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandCompare" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandCompare" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
-    </CommandPlacement>-->
-    
     <!-- Document Tab context menu | Compare  -->
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandCompare" priority="0x0600">
       <Parent guid="guidSccProviderCmdSet" id="igrpDocTabWnd"/>

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -125,7 +125,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>IconAndText</CommandFlag>
         <Strings>
-          <ButtonText>Git Compare with Last Commit...</ButtonText>
+          <ButtonText>Compare with Last Commit...</ButtonText>
         </Strings>
       </Button>
       
@@ -136,7 +136,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>IconAndText</CommandFlag>
         <Strings>
-          <ButtonText>Git Undo File Changes</ButtonText>
+          <ButtonText>Undo File Changes</ButtonText>
         </Strings>
       </Button>
 
@@ -158,7 +158,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>IconAndText</CommandFlag>
         <Strings>
-          <ButtonText>Git Refresh</ButtonText>
+          <ButtonText>Refresh</ButtonText>
         </Strings>
       </Button>
 
@@ -203,7 +203,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>IconAndText</CommandFlag>
         <Strings>
-          <ButtonText>Git Pending Changes</ButtonText>
+          <ButtonText>Pending Changes</ButtonText>
         </Strings>
       </Button>
 
@@ -214,7 +214,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>IconAndText</CommandFlag>
         <Strings>
-          <ButtonText>Git History</ButtonText>
+          <ButtonText>History</ButtonText>
         </Strings>
       </Button>
       

--- a/PkgCmd.vsct
+++ b/PkgCmd.vsct
@@ -53,6 +53,10 @@
         <Parent guid="guidSccProviderCmdSet" id="imnuGitSourceControlMenu"/>
       </Group>
 
+      <Group guid="guidSccProviderCmdSet" id="igrpGeneralSourceControlCommands" priority="0x0080">
+        <Parent guid="guidSccProviderCmdSet" id="imnuGitSourceControlMenu"/>
+      </Group>
+
       <Group guid="guidSccProviderCmdSet" id="igrpPendingChangesToolWindowToolbarGroup" priority="0x0100">
         <Parent guid="guidSccProviderCmdSet" id="imnuPendingChangesToolWindowToolbarMenu"/>
       </Group>
@@ -82,7 +86,7 @@
     <Buttons>
      
       <Button guid="guidSccProviderCmdSet" id="icmdSccCommandGitBash" priority="0x0106" type="Button">
-        <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
+        <Parent guid="guidSccProviderCmdSet" id="igrpGeneralSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconGitBash" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -137,7 +141,7 @@
       </Button>
 
       <Button guid="guidSccProviderCmdSet" id="icmdSccCommandEditIgnore" priority="0x0103" type="Button">
-        <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
+        <Parent guid="guidSccProviderCmdSet" id="igrpGeneralSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconGitBash" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -148,7 +152,7 @@
       </Button>
 
       <Button guid="guidSccProviderCmdSet" id="icmdSccCommandRefresh" priority="0x0104" type="Button">
-        <!--<Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>-->
+        <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconGitBash" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -193,6 +197,7 @@
       </Button>
 
       <Button guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0101" type="Button">
+        <Parent guid="guidSccProviderCmdSet" id="igrpGeneralSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconGitBash" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -203,7 +208,7 @@
       </Button>
 
       <Button guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0105" type="Button">
-        <!--<Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>-->
+        <Parent guid="guidSccProviderCmdSet" id="igrpSourceControlCommands"/>
         <Icon guid="guidSccProviderImages" id="iconGitBash" />
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
@@ -289,16 +294,6 @@
     </CommandPlacement>
 
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0003">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
-    </CommandPlacement>
-
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandPendingChanges" priority="0x0003">
       <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS0"/>
     </CommandPlacement>
     
@@ -308,26 +303,6 @@
     </CommandPlacement>
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandUndo" priority="0x0601">
       <Parent guid="guidSccProviderCmdSet" id="igrpDocTabWnd"/>
-    </CommandPlacement>
-    
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandHistory" priority="0x0004">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
-    </CommandPlacement>
-
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandRefresh" priority="0x0005">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_ITEM_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandRefresh" priority="0x0005">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_SCC"/>
-    </CommandPlacement>
-    <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandRefresh" priority="0x0005">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CTXT_SOLUTION_SCC"/>
     </CommandPlacement>
     
     <CommandPlacement guid="guidSccProviderCmdSet" id="icmdSccCommandEditIgnore" priority="0x0007">
@@ -389,8 +364,10 @@
       <IDSymbol name="icmdPendingChangesCommitToBranch" value="0x113"/>
 
       <IDSymbol name="icmdPendingChangesRefresh" value="0x114"/>
-      <IDSymbol name="icmdHistoryViewRefresh" value="0x115"/>  
-      
+      <IDSymbol name="icmdHistoryViewRefresh" value="0x115"/>
+
+      <IDSymbol name="igrpGeneralSourceControlCommands" value="0x700"/>
+      <IDSymbol name="imnuGeneralSourceControlCommands" value="0x701"/>
       <IDSymbol name="igrpGitExtCommands" value="0x800"/>
       <IDSymbol name="imnuGitExtMenu" value="0x801"/>
       <IDSymbol name="igrpGitTorCommands" value="0x900"/>

--- a/SccProviderService.cs
+++ b/SccProviderService.cs
@@ -28,7 +28,7 @@ namespace GitScc
 {
     [Guid("C4128D99-1000-41D1-A6C3-704E6C1A3DE2")]
     public class SccProviderService : IVsSccProvider,
-        IVsSccManager2,
+        IVsSccManager3,
         IVsSccManagerTooltip,
         IVsSolutionEvents,
         IVsSolutionEvents2,
@@ -234,6 +234,15 @@ namespace GitScc
         public int UnregisterSccProject([InAttribute] IVsSccProject2 pscp2Project)
         {
             return VSConstants.S_OK;
+        }
+
+        #endregion
+
+        #region IVsSccManager3 Members
+
+        public bool IsBSLSupported()
+        {
+            return true;
         }
 
         #endregion

--- a/SccProviderService.cs
+++ b/SccProviderService.cs
@@ -214,18 +214,9 @@ namespace GitScc
         /// </summary>
         public int GetSccGlyphFromStatus([InAttribute] uint dwSccStatus, [OutAttribute] VsStateIcon[] psiGlyph)
         {
-            //switch (dwSccStatus)
-            //{
-            //    case (uint)__SccStatus.SCC_STATUS_CHECKEDOUT:
-            //        psiGlyph[0] = VsStateIcon.STATEICON_CHECKEDOUT;
-            //        break;
-            //    case (uint)__SccStatus.SCC_STATUS_CONTROLLED:
-            //        psiGlyph[0] = VsStateIcon.STATEICON_CHECKEDIN;
-            //        break;
-            //    default:
-            //        psiGlyph[0] = VsStateIcon.STATEICON_BLANK;
-            //        break;
-            //}
+            // This method is called when some user (e.g. like classview) wants to combine icons
+            // (Unfortunately classview uses a hardcoded mapping)
+            psiGlyph[0] = VsStateIcon.STATEICON_BLANK;
             return VSConstants.S_OK;
         }
 

--- a/SccProviderService.cs
+++ b/SccProviderService.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 using CancellationToken = System.Threading.CancellationToken;
+using CommandID = System.ComponentModel.Design.CommandID;
 using Constants = NGit.Constants;
 using Interlocked = System.Threading.Interlocked;
 using Task = System.Threading.Tasks.Task;
@@ -107,6 +108,10 @@ namespace GitScc
         {
             Trace.WriteLine(String.Format(CultureInfo.CurrentUICulture, "Git Source Control Provider set active"));
             _active = true;
+
+            GlobalCommandHook hook = GlobalCommandHook.GetInstance(_sccProvider);
+            hook.HookCommand(new CommandID(VSConstants.VSStd2K, (int)VSConstants.VSStd2KCmdID.SLNREFRESH), HandleSolutionRefresh);
+
             MarkDirty(false);
             return VSConstants.S_OK;
         }
@@ -117,6 +122,10 @@ namespace GitScc
         {
             Trace.WriteLine(String.Format(CultureInfo.CurrentUICulture, "Git Source Control Provider set inactive"));
             _active = false;
+
+            GlobalCommandHook hook = GlobalCommandHook.GetInstance(_sccProvider);
+            hook.UnhookCommand(new CommandID(VSConstants.VSStd2K, (int)VSConstants.VSStd2KCmdID.SLNREFRESH), HandleSolutionRefresh);
+
             CloseTracker();
             MarkDirty(false);
             return VSConstants.S_OK;
@@ -128,6 +137,11 @@ namespace GitScc
             return VSConstants.S_OK;
         }
         #endregion
+
+        private void HandleSolutionRefresh(object sender, EventArgs e)
+        {
+            Refresh();
+        }
 
         #region IVsSccManager2 interface functions
 


### PR DESCRIPTION
- Remove the non-standard About command from the context menus and the Pending Changes window toolbar
- Move Git commands from the top-level context menu to the Git submenu
- Simplify command labels for items on the Git submenu
- Refresh the SCC status in response to the Solution Refresh command (the refresh button on the Solution Explorer toolbar)
- Allow background solution loading in Visual Studio 2012
