### PR TITLE
UI tweaks

### DIFF
--- a/PendingChangesToolWindow.cs
+++ b/PendingChangesToolWindow.cs
@@ -94,7 +94,7 @@ namespace GitScc
             try
             {
                 var repository = (tracker == null || !tracker.HasGitRepository) ? "" :
-                    string.Format(" - {0}", tracker.CurrentBranch, tracker.GitWorkingDirectory);
+                    string.Format(" ({0})", tracker.CurrentBranch, tracker.GitWorkingDirectory);
 
                 this.Caption = Resources.ResourceManager.GetString("PendingChangesToolWindowCaption") + repository;
 

--- a/PendingChangesView.xaml.cs
+++ b/PendingChangesView.xaml.cs
@@ -313,7 +313,7 @@ namespace GitScc
                         ShowStatusMessage("");
 
                         var changed = changedFiles;
-                        this.label3.Content = string.Format("Changed files: ({0}) +{1} ~{2} -{3} !{4}", tracker.CurrentBranch,
+                        this.label3.Content = string.Format("Changed files (+{0} ~{1} -{2} !{3})",
                             changed.Where(f => f.Status == GitFileStatus.New || f.Status == GitFileStatus.Added).Count(),
                             changed.Where(f => f.Status == GitFileStatus.Modified || f.Status == GitFileStatus.Staged).Count(),
                             changed.Where(f => f.Status == GitFileStatus.Deleted || f.Status == GitFileStatus.Removed).Count(),

--- a/Resources.Designer.cs
+++ b/Resources.Designer.cs
@@ -127,7 +127,7 @@ namespace GitScc {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Git Pending Changes.
+        ///   Looks up a localized string similar to Pending Changes.
         /// </summary>
         internal static string PendingChangesToolWindowCaption {
             get {

--- a/Resources.resx
+++ b/Resources.resx
@@ -143,7 +143,7 @@
     <value>CIP0H8JCC9JAJMRZE8H3J2IPADZQI9QIRHMKQPH2E8EDPDPEHCJQPDZEZRI1J8D3D8KHZPRQCEEDIPK3MKDDA9IEAACCMIPAQ0JCEQPHD0RPHDZRZKC2RDHERTDCKDPM</value>
   </data>
   <data name="PendingChangesToolWindowCaption" xml:space="preserve">
-    <value>Git Pending Changes</value>
+    <value>Pending Changes</value>
   </data>
   <data name="HistoryToolWindowCaption" xml:space="preserve">
     <value>Git History</value>


### PR DESCRIPTION
- Update caption of Pending Changes window to be consistent with Solution Explorer and other SCC plugins
  - Was: `Git Pending Changes - branch`
  - Now: `Pending Changes (branch)`
- Simplify label in Pending Changes window since the branch name is already included in the window caption
