### PR TITLE
Fix compilation error because of missing Mono.Posix.dll

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -225,7 +225,6 @@
     <EmbeddedResource Include="Resources\GitApi.dll" />
     <EmbeddedResource Include="Resources\ICSharpCode.AvalonEdit.dll" />
     <EmbeddedResource Include="Resources\ICSharpCode.SharpZipLib.dll" />
-    <EmbeddedResource Include="Resources\Mono.Posix.dll" />
     <EmbeddedResource Include="Resources\Mono.Security.dll" />
     <EmbeddedResource Include="Resources\NGit.dll" />
     <EmbeddedResource Include="Resources\NSch.dll" />


### PR DESCRIPTION
Removed dependency on Mono.Posix.dll because "this assembly is only
required when running NGit on MacOS or Linux operating system." (See
nGit readme file)
