### PR TITLE
Rename bundled GitDiffMargin to not conflict with unbundled extension.

### DIFF
--- a/Diff/DiffMargin.cs
+++ b/Diff/DiffMargin.cs
@@ -13,7 +13,7 @@
 
     public sealed class DiffMargin : IWpfTextViewMargin
     {
-        public const string MarginName = "GitDiffMargin";
+        public const string MarginName = "GitSccDiffMargin";
 
         internal const double ChangeLeft = 2.5;
         internal const double ChangeWidth = 5.0;


### PR DESCRIPTION
This commit renames the bundled diff margin not to conflict with the unbundled one so that both extensions can be used at the same time without conflict.
